### PR TITLE
Fix udev taking a long time with eruption

### DIFF
--- a/support/udev/99-eruption-roccat-vulcan.rules
+++ b/support/udev/99-eruption-roccat-vulcan.rules
@@ -1,5 +1,5 @@
-ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e7d", ATTRS{idProduct}=="307a", RUN+="/usr/bin/systemctl start eruption.service"
-ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e7d", ATTRS{idProduct}=="3098", RUN+="/usr/bin/systemctl start eruption.service"
+ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e7d", ATTRS{idProduct}=="307a", TAG+="systemd", ENV{SYSTEMD_WANTS}="eruption.service"
+ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e7d", ATTRS{idProduct}=="3098", TAG+="systemd", ENV{SYSTEMD_WANTS}="eruption.service"
 
 #ACTION=="change", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e7d", ATTRS{idProduct}=="307a", RUN+="/usr/bin/systemctl try-reload-or-restart eruption.service"
 #ACTION=="change", SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e7d", ATTRS{idProduct}=="3098", RUN+="/usr/bin/systemctl try-reload-or-restart eruption.service"


### PR DESCRIPTION
You launch service units by doing this, not by using systemctl.. See https://coreos.com/os/docs/latest/using-systemd-and-udev-rules.html for example..

The way you have it, it takes >60s for system to start, because udev is trying to launch systemd which is launching udev. (I think).