### PR TITLE
Update README.md - Prevent service from running by disabling eruption systemd service script

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ the following text snippet to the bootloader's (e.g. GRUB) kernel command line:
 ```
 Or with systemctl to mask/disable the service:
 ```sh
-$ sudo systemctl mask eruption
+$ sudo systemctl mask eruption.service
 ```
 You can always re-enable the Eruption service with the command:
 ```sh
-$ sudo systemctl enable eruption
+$ sudo systemctl enable eruption.service
 ```
 
 ## Overview <a name="overview"></a>

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ or prevent the service from starting by disabling
 $ sudo systemctl disable eruption
 ```
 
-
 ## Overview <a name="overview"></a>
 
 Eruption is a Linux daemon written in Rust, consisting of a core, an integrated

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ the following text snippet to the bootloader's (e.g. GRUB) kernel command line:
 ```sh
   systemd.mask=eruption.service
 ```
+or prevent the service from starting by disabling
+```sh
+$ sudo systemctl disable eruption
+```
+
 
 ## Overview <a name="overview"></a>
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,13 @@ the following text snippet to the bootloader's (e.g. GRUB) kernel command line:
 ```sh
   systemd.mask=eruption.service
 ```
-or prevent the service from starting by disabling
+Or with systemctl to mask/disable the service:
 ```sh
-$ sudo systemctl disable eruption
+$ sudo systemctl mask eruption
+```
+You can always re-enable the Eruption service with the command:
+```sh
+$ sudo systemctl enable eruption
 ```
 
 ## Overview <a name="overview"></a>


### PR DESCRIPTION
Although I have the package installed,  I don't have the kernel parameter set as described in the `README.md` and am able to prevent the eruption from running by simply disabling the service.  I would ask that providing this information be described as an option for users.